### PR TITLE
Fix uninitialized constant GoogleOauth2Installed::Setup::Forwardable

### DIFF
--- a/lib/google-oauth2-installed/setup.rb
+++ b/lib/google-oauth2-installed/setup.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module GoogleOauth2Installed
   # To be used interactively.
   # See `GoogleOauth2Installed.get_access_token`


### PR DESCRIPTION
Hello,

I have this issue while loading the gem in a ruby file:
`Uncaught exception: uninitialized constant GoogleOauth2Installed::Setup::Forwardable`

I fix it by adding `require 'forwardable'` on the top of the setup.rb file.

May this help!
